### PR TITLE
Update xfce4-pkg-list

### DIFF
--- a/xfce4-pkg-list
+++ b/xfce4-pkg-list
@@ -29,7 +29,6 @@ lightdm-gtk-greeter-settings
 capitaine-cursors
 arc-x-icons-theme
 arc-gtk-theme
-gnome-packagekit
 endeavouros-xfce4-terminal-colors
 xdg-user-dirs-gtk
 qt5ct


### PR DESCRIPTION
removed gnome-packagekit this is also removed from EndeavourOS Main installs