### PR TITLE
Update gnome-pkg-list

### DIFF
--- a/gnome-pkg-list
+++ b/gnome-pkg-list
@@ -4,7 +4,6 @@ nautilus-sendto
 gnome-nettool
 gnome-usage
 adwaita-icon-theme
-gnome-packagekit
 gnome-software-packagekit-plugin
 xdg-user-dirs-gtk
 fwupd


### PR DESCRIPTION
remove gnome-packagekit we do use pacman and yay .. gnome-software should be removed also, but this need to have a package removal script included