### PR TITLE
Update kde-pkg-list

### DIFF
--- a/kde-pkg-list
+++ b/kde-pkg-list
@@ -1,5 +1,4 @@
 plasma
-packagekit-qt5
 kdeconnect
 fwupd
 python-dbus


### PR DESCRIPTION
packagekit-qt5 removal, plus Discover should be removed also, it is most likely not usable at ARM devices at all very hungry on rescourses