### PR TITLE
Handle edge case of "pacman -S" failing when installing EnOS Base Addons

### DIFF
--- a/endeavour-ARM-install-V1.0.sh
+++ b/endeavour-ARM-install-V1.0.sh
@@ -622,14 +622,9 @@ message="\nInstalling EndeavourOS Base Addons  "
 sleep 2
 if [ "$installtype" == "desktop" ]
 then
-   pacman -S --noconfirm --needed - < base-addons
-   systemctl enable dhcpcd.service
+   pacman -S --noconfirm --needed - < base-addons && systemctl enable dhcpcd.service
 else
-   pacman -S --noconfirm --needed - < server-addons
-   dhcpcd_installed=$(pacman -Qs dhcpcd)
-    if [[ "$dhcpcd_installed" != "" ]]; then 
-      pacman -Rn --noconfirm dhcpcd
-   fi
+   pacman -S --noconfirm --needed - < server-addons && pacman -Q dhcpcd &> /dev/null && pacman -Rn --noconfirm dhcpcd
 fi
 ok_nok   # function call
 


### PR DESCRIPTION
When installing on my Raspberry Pi 4 Model B, the mirror I selected (Sydney) was missing one package out of the base-addons install, so the "pacman -S command failed because of a 404 error on the missing package on the mirror. 

The "ok_nok" function call after the "if...then...else" code block didn't catch it as failed, however, I think because the "systemctl enable dhcpcd.service" command that is after the pacman command and before the ok_nok call succeeded.

So, I have changed the commands in the  "if...then...else" code block to be in a single line with logical AND between each, so that this (albeit unlikely!) edge case is handled correctly.